### PR TITLE
Add dockerfiles/Dockerfile.windows.devel

### DIFF
--- a/dockerfiles/Dockerfile.windows.devel
+++ b/dockerfiles/Dockerfile.windows.devel
@@ -1,0 +1,102 @@
+# escape=`
+
+ARG WINDOWS_VERSION=ltsc2019
+
+#
+# Builder Image - Windows Server Core
+#
+FROM mcr.microsoft.com/windows/servercore:$WINDOWS_VERSION as builder
+
+# The FLUENTBIT_VERSION ARG must be after the FROM instruction
+ARG FLUENTBIT_VERSION
+ARG IMAGE_CREATE_DATE
+ARG IMAGE_SOURCE_REVISION
+
+# Metadata as defined in OCI image spec annotations
+# https://github.com/opencontainers/image-spec/blob/master/annotations.md
+LABEL org.opencontainers.image.title="Fluent Bit" `
+      org.opencontainers.image.description="Fluent Bit is an open source and multi-platform Log Processor and Forwarder which allows you to collect data/logs from different sources, unify and send them to multiple destinations. It's fully compatible with Docker and Kubernetes environments." `
+      org.opencontainers.image.created=$IMAGE_CREATE_DATE `
+      org.opencontainers.image.version=$FLUENTBIT_VERSION `
+      org.opencontainers.image.authors="Eduardo Silva <eduardo@treasure-data.com>" `
+      org.opencontainers.image.url="https://hub.docker.com/r/fluent/fluent-bit" `
+      org.opencontainers.image.documentation="https://docs.fluentbit.io/manual/" `
+      org.opencontainers.image.vendor="Fluent Organization" `
+      org.opencontainers.image.licenses="Apache-2.0" `
+      org.opencontainers.image.source="https://github.com/fluent/fluent-bit" `
+      org.opencontainers.image.revision=$IMAGE_SOURCE_REVISION
+
+#
+# Basic setup
+#
+RUN setx /M PATH "%PATH%;C:\BuildTools\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin"
+RUN setx /M PATH "%PATH%;C:\WinFlexBison"
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+RUN Write-Host ('Creating folders'); `
+    New-Item -Type Directory -Path /local; `
+    New-Item -Type Directory -Path /fluent-bit/bin;
+
+WORKDIR /local
+
+#
+# Install Visual Studio 2019
+#
+ADD https://aka.ms/vs/16/release/vs_buildtools.exe /local/vs_buildtools.exe
+ADD https://aka.ms/vs/16/release/channel /local/VisualStudio.chman
+
+RUN Start-Process /local/vs_buildtools.exe `
+    -ArgumentList '--quiet ', '--wait ', '--norestart ', '--nocache', `
+    '--installPath C:\BuildTools', `
+    '--channelUri C:\local\VisualStudio.chman', `
+    '--installChannelUri C:\local\VisualStudio.chman', `
+    '--add Microsoft.VisualStudio.Workload.VCTools', `
+    '--includeRecommended'  -NoNewWindow -Wait;
+
+#
+# Technique from https://github.com/StefanScherer/dockerfiles-windows/blob/master/mongo/3.6/Dockerfile
+#
+ADD https://aka.ms/vs/15/release/vc_redist.x64.exe /local/vc_redist.x64.exe
+
+RUN Write-Host ('Installing Visual C++ Redistributable Package'); `
+    Start-Process /local/vc_redist.x64.exe -ArgumentList '/install', '/quiet', '/norestart' -NoNewWindow -Wait; `
+    Copy-Item -Path /Windows/System32/msvcp140.dll -Destination /fluent-bit/bin/; `
+    Copy-Item -Path /Windows/System32/vccorlib140.dll -Destination /fluent-bit/bin/; `
+    Copy-Item -Path /Windows/System32/vcruntime140.dll -Destination /fluent-bit/bin/;
+
+#
+# Install winflexbison
+#
+ADD https://github.com/lexxmark/winflexbison/releases/download/v2.5.22/win_flex_bison-2.5.22.zip /local/win_flex_bison.zip
+
+RUN Expand-Archive /local/win_flex_bison.zip -Destination /WinFlexBison; `
+    Copy-Item -Path /WinFlexBison/win_bison.exe /WinFlexBison/bison.exe; `
+    Copy-Item -Path /WinFlexBison/win_flex.exe /WinFlexBison/flex.exe;
+
+#
+# Install Fluent Bit
+#
+COPY . /src/
+
+WORKDIR /src/build
+
+RUN cmake -G "'Visual Studio 16 2019'" -DCMAKE_BUILD_TYPE=Release ../;
+
+RUN cmake --build . --config Release;
+
+RUN Copy-Item /src/build/bin/Release/fluent-bit.exe /fluent-bit/bin/; `
+    Copy-Item /src/build/bin/Release/fluent-bit.dll /fluent-bit/bin/; `
+    Copy-Item -Recurse /src/include /fluent-bit; `
+    Copy-Item -Recurse /src/conf /fluent-bit;
+
+#
+# Runtime Image - Windows Server Nano
+#
+FROM mcr.microsoft.com/windows/servercore:$WINDOWS_VERSION as runtime
+
+COPY --from=builder /fluent-bit /fluent-bit
+
+RUN setx /M PATH "%PATH%;C:\fluent-bit\bin"
+
+ENTRYPOINT ["fluent-bit.exe", "-i", "dummy", "-o", "stdout"]


### PR DESCRIPTION
This is needed for Anthos pipeline to build the windows image.

More information here:
https://github.com/fluent/fluent-bit/discussions/5007#discussioncomment-2524868

<!-- Provide summary of changes -->
Add dockerfiles/Dockerfile.windows.devel
 
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->
[N/A]

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [ ] Example configuration file for the change
- [ ] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [ ] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [ ] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [ ] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [ ] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
